### PR TITLE
Update to OBS 31.0.1 theme

### DIFF
--- a/obs.tera
+++ b/obs.tera
@@ -34,6 +34,94 @@ VolumeMeter {
 
 {%- set icon_theme = if(cond=flavor.dark, t="Dark", f="Light") %}
 
+/* Icon Overrides */
+
+.icon-plus {
+    qproperty-icon: url(theme:{{ icon_theme}}/plus.svg);
+}
+
+.icon-minus {
+    qproperty-icon: url(theme:{{ icon_theme}}/minus.svg);
+}
+
+.icon-trash {
+    qproperty-icon: url(theme:{{ icon_theme}}/trash.svg);
+}
+
+.icon-clear {
+    qproperty-icon: url(theme:{{ icon_theme}}/entry-clear.svg);
+}
+
+.icon-gear {
+    qproperty-icon: url(theme:{{ icon_theme}}/settings/general.svg);
+}
+
+.icon-dots-vert {
+    qproperty-icon: url(theme:{{ icon_theme}}/dots-vert.svg);
+}
+
+.icon-refresh {
+    qproperty-icon: url(theme:{{ icon_theme}}/refresh.svg);
+}
+
+.icon-cogs {
+    qproperty-icon: url(theme:{{ icon_theme}}/cogs.svg);
+}
+
+.icon-touch {
+    qproperty-icon: url(theme:{{ icon_theme}}/interact.svg);
+}
+
+.icon-up {
+    qproperty-icon: url(theme:{{ icon_theme}}/up.svg);
+}
+
+.icon-down {
+    qproperty-icon: url(theme:{{ icon_theme}}/down.svg);
+}
+
+.icon-pause {
+    qproperty-icon: url(theme:{{ icon_theme}}/media-pause.svg);
+}
+
+.icon-filter {
+    qproperty-icon: url(theme:{{ icon_theme}}/filter.svg);
+}
+
+.icon-revert {
+    qproperty-icon: url(theme:{{ icon_theme}}/revert.svg);
+}
+
+.icon-save {
+    qproperty-icon: url(theme:{{ icon_theme}}/save.svg);
+}
+
+/* Media icons */
+
+.icon-media-play {
+    qproperty-icon: url(theme:{{ icon_theme}}/media/media_play.svg);
+}
+
+.icon-media-pause {
+    qproperty-icon: url(theme:{{ icon_theme}}/media/media_pause.svg);
+}
+
+.icon-media-restart {
+    qproperty-icon: url(theme:{{ icon_theme}}/media/media_restart.svg);
+}
+
+.icon-media-stop {
+    qproperty-icon: url(theme:{{ icon_theme}}/media/media_stop.svg);
+}
+
+.icon-media-next {
+    qproperty-icon: url(theme:{{ icon_theme}}/media/media_next.svg);
+}
+
+.icon-media-prev {
+    qproperty-icon: url(theme:{{ icon_theme}}/media/media_previous.svg);
+}
+
 /* Context Menu */
 QMenu::right-arrow {
     image: url(theme:{{ icon_theme }}/expand.svg);
@@ -55,58 +143,6 @@ QPushButton#sourceFiltersButton {
 }
 
 /* Scenes and Sources toolbar */
-* [themeID="addIconSmall"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/plus.svg);
-}
-
-* [themeID="removeIconSmall"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/trash.svg);
-}
-
-* [themeID="clearIconSmall"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/entry-clear.svg);
-}
-
-* [themeID="propertiesIconSmall"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/settings/general.svg);
-}
-
-* [themeID="configIconSmall"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/settings/general.svg);
-}
-
-* [themeID="menuIconSmall"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/dots-vert.svg);
-}
-
-* [themeID="refreshIconSmall"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/refresh.svg);
-}
-
-* [themeID="cogsIcon"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/cogs.svg);
-}
-
-#sourceInteractButton {
-    qproperty-icon: url(theme:{{ icon_theme }}/interact.svg);
-}
-
-* [themeID="upArrowIconSmall"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/up.svg);
-}
-
-* [themeID="downArrowIconSmall"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/down.svg);
-}
-
-* [themeID="pauseIconSmall"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/media-pause.svg);
-}
-
-* [themeID="filtersIcon"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/filter.svg);
-}
-
 QToolBarExtension {
     qproperty-icon: url(theme:{{ icon_theme }}/dots-vert.svg);
 }
@@ -119,7 +155,7 @@ QDateTimeEdit::down-arrow {
 
 QComboBox::down-arrow:editable,
 QDateTimeEdit::down-arrow:editable {
-    image: url(theme:{{ icon_theme }}/down.svg);
+    image: url(theme:{{ icon_theme }}/collapse.svg);
 }
 
 /* Spinbox and doubleSpinbox */
@@ -181,66 +217,62 @@ QGroupBox::indicator:checked:disabled {
 }
 
 /* Locked CheckBox */
-QCheckBox[lockCheckBox=true]::indicator:checked,
-QCheckBox[lockCheckBox=true]::indicator:checked:hover {
+.indicator-lock::indicator:checked,
+.indicator-lock::indicator:checked:hover {
     image: url(theme:{{ icon_theme }}/locked.svg);
 }
 
 /* Visibility CheckBox */
-QCheckBox[visibilityCheckBox=true]::indicator:checked,
-QCheckBox[visibilityCheckBox=true]::indicator:checked:hover {
+.indicator-visibility::indicator:checked,
+.indicator-visibility::indicator:checked:hover {
     image: url(theme:{{ icon_theme }}/visible.svg);
 }
 
-* [themeID="revertIcon"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/revert.svg);
-}
-
 /* Mute CheckBox */
-MuteCheckBox::indicator:checked {
+.indicator-mute::indicator:checked {
     image: url(theme:{{ icon_theme }}/mute.svg);
 }
 
-MuteCheckBox::indicator:indeterminate {
+.indicator-mute::indicator:indeterminate {
     image: url(theme:{{ icon_theme }}/unassigned.svg);
 }
 
-MuteCheckBox::indicator:unchecked {
+.indicator-mute::indicator:unchecked {
     image: url(theme:{{ icon_theme }}/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:unchecked:hover {
+.indicator-mute::indicator:unchecked:hover {
     image: url(theme:{{ icon_theme }}/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:unchecked:focus {
+.indicator-mute::indicator:unchecked:focus {
     image: url(theme:{{ icon_theme }}/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:checked:hover {
+.indicator-mute::indicator:checked:hover {
     image: url(theme:{{ icon_theme }}/mute.svg);
 }
 
-MuteCheckBox::indicator:checked:focus {
+.indicator-mute::indicator:checked:focus {
     image: url(theme:{{ icon_theme }}/mute.svg);
 }
 
-MuteCheckBox::indicator:checked:disabled {
+.indicator-mute::indicator:checked:disabled {
     image: url(theme:{{ icon_theme }}/mute.svg);
 }
 
-MuteCheckBox::indicator:unchecked:disabled {
+.indicator-mute::indicator:unchecked:disabled {
     image: url(theme:{{ icon_theme }}/settings/audio.svg);
 }
 
 /* Sources List Group Collapse Checkbox */
-QCheckBox[sourceTreeSubItem=true]::indicator:checked,
-QCheckBox[sourceTreeSubItem=true]::indicator:checked:hover {
+.indicator-expand::indicator:checked,
+.indicator-expand::indicator:checked:hover {
     image: url(theme:{{ icon_theme }}/expand.svg);
 }
 
-QCheckBox[sourceTreeSubItem=true]::indicator:unchecked,
-QCheckBox[sourceTreeSubItem=true]::indicator:unchecked:hover {
+.indicator-expand::indicator:unchecked,
+.indicator-expand::indicator:unchecked:hover {
     image: url(theme:{{ icon_theme }}/collapse.svg);
 }
 
@@ -262,36 +294,6 @@ OBSBasic {
     qproperty-sceneIcon: url(theme:{{ icon_theme }}/sources/scene.svg);
     qproperty-defaultIcon: url(theme:{{ icon_theme }}/sources/default.svg);
     qproperty-audioProcessOutputIcon: url(theme:{{ icon_theme }}/sources/windowaudio.svg);
-}
-
-/* Save icon */
-* [themeID="replayIconSmall"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/save.svg);
-}
-
-/* Media icons */
-* [themeID="playIcon"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/media/media_play.svg);
-}
-
-* [themeID="pauseIcon"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/media/media_pause.svg);
-}
-
-* [themeID="restartIcon"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/media/media_restart.svg);
-}
-
-* [themeID="stopIcon"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/media/media_stop.svg);
-}
-
-* [themeID="nextIcon"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/media/media_next.svg);
-}
-
-* [themeID="previousIcon"] {
-    qproperty-icon: url(theme:{{ icon_theme }}/media/media_previous.svg);
 }
 
 /* YouTube Integration */

--- a/themes/Catppuccin.obt
+++ b/themes/Catppuccin.obt
@@ -108,6 +108,146 @@
     --spacing_input: var(--spacing_base);
 }
 
+/* --------------------- */
+/* General Styling Hints */
+
+/* Backgrounds */
+
+.bg_window {
+    background-color: var(--ctp_base);
+}
+
+.bg-base {
+    background-color: palette(base);
+}
+
+.text-heading {
+    font-size: var(--font_heading);
+    font-weight: bold;
+}
+
+.text-large {
+    font-size: var(--font_large);
+}
+
+.text-bright {
+    color: var(--ctp_surface0);
+}
+
+.text-muted {
+    color: var(--ctp_overlay1);
+}
+
+.text-warning {
+    color: var(--ctp_peach);
+}
+
+.text-danger {
+    color: var(--ctp_maroon);
+}
+
+.text-success {
+    color: var(--ctp_green);
+}
+
+.frame-notice {
+    background: var(--ctp_crust);
+    border-radius: var(--border_radius);
+    padding: var(--padding_xlarge) var(--padding_large);
+}
+
+.frame-notice QLabel {
+    padding: var(--padding_large) 0px;
+}
+
+/* Icon Overrides */
+
+.icon-plus {
+    qproperty-icon: url(theme:Dark/plus.svg);
+}
+
+.icon-minus {
+    qproperty-icon: url(theme:Dark/minus.svg);
+}
+
+.icon-trash {
+    qproperty-icon: url(theme:Dark/trash.svg);
+}
+
+.icon-clear {
+    qproperty-icon: url(theme:Dark/entry-clear.svg);
+}
+
+.icon-gear {
+    qproperty-icon: url(theme:Dark/settings/general.svg);
+}
+
+.icon-dots-vert {
+    qproperty-icon: url(theme:Dark/dots-vert.svg);
+}
+
+.icon-refresh {
+    qproperty-icon: url(theme:Dark/refresh.svg);
+}
+
+.icon-cogs {
+    qproperty-icon: url(theme:Dark/cogs.svg);
+}
+
+.icon-touch {
+    qproperty-icon: url(theme:Dark/interact.svg);
+}
+
+.icon-up {
+    qproperty-icon: url(theme:Dark/up.svg);
+}
+
+.icon-down {
+    qproperty-icon: url(theme:Dark/down.svg);
+}
+
+.icon-pause {
+    qproperty-icon: url(theme:Dark/media-pause.svg);
+}
+
+.icon-filter {
+    qproperty-icon: url(theme:Dark/filter.svg);
+}
+
+.icon-revert {
+    qproperty-icon: url(theme:Dark/revert.svg);
+}
+
+.icon-save {
+    qproperty-icon: url(theme:Dark/save.svg);
+}
+
+/* Media icons */
+
+.icon-media-play {
+    qproperty-icon: url(theme:Dark/media/media_play.svg);
+}
+
+.icon-media-pause {
+    qproperty-icon: url(theme:Dark/media/media_pause.svg);
+}
+
+.icon-media-restart {
+    qproperty-icon: url(theme:Dark/media/media_restart.svg);
+}
+
+.icon-media-stop {
+    qproperty-icon: url(theme:Dark/media/media_stop.svg);
+}
+
+.icon-media-next {
+    qproperty-icon: url(theme:Dark/media/media_next.svg);
+}
+
+.icon-media-prev {
+    qproperty-icon: url(theme:Dark/media/media_previous.svg);
+}
+
 /* Default widget style, we override only what is needed. */
 
 QWidget {
@@ -171,7 +311,12 @@ SourceTree QWidget {
     margin-bottom: 0;
 }
 
-* [frameShape="1"], * [frameShape="2"], * [frameShape="3"], * [frameShape="4"], * [frameShape="5"], * [frameShape="6"] {
+* [frameShape="1"],
+* [frameShape="2"],
+* [frameShape="3"],
+* [frameShape="4"],
+* [frameShape="5"],
+* [frameShape="6"] {
     border: 1px solid palette(dark);
 }
 
@@ -242,6 +387,7 @@ SceneTree::item {
 
 QMenu::item {
     padding: var(--padding_large) var(--padding_menu);
+    padding-right: 20px;
 }
 
 QListWidget::item,
@@ -301,10 +447,10 @@ SceneTree::item:disabled:hover {
 QListWidget QLineEdit,
 SceneTree QLineEdit,
 SourceTree QLineEdit {
-    padding:  0;
+    padding: 0;
     padding-bottom: 1px;
-    margin: 0px;
-    border: 1 solid var(--ctp_text);
+    margin: 0;
+    border: 1px solid var(--ctp_text);
     border-radius: var(--border_radius);
 }
 
@@ -327,13 +473,13 @@ OBSBasicSettings QListWidget::item {
 }
 
 OBSBasicSettings QScrollBar:vertical {
-  width: var(--settings_scrollbar_size);
-  margin-left: 9px;
+    width: var(--settings_scrollbar_size);
+    margin-left: 9px;
 }
 
 OBSBasicSettings QScrollBar:horizontal {
-  height: var(--settings_scrollbar_size);
-  margin-top: 9px;
+    height: var(--settings_scrollbar_size);
+    margin-top: 9px;
 }
 
 /* Settings properties view */
@@ -508,12 +654,17 @@ QScrollBar::handle:horizontal {
     min-width: 32px;
 }
 
+QScrollBar::handle:disabled {
+    background: transparent;
+    border-color: transparent;
+}
+
 /* Source Context Bar */
 
 #contextContainer {
-  background-color: palette(dark);
-  margin-top: 4px;
-  border-radius: var(--border_radius);
+    background-color: palette(dark);
+    margin-top: 4px;
+    border-radius: var(--border_radius);
 }
 
 #contextContainer QPushButton {
@@ -539,58 +690,6 @@ QToolBar {
     margin: var(--spacing_base) 0px;
 }
 
-* [themeID="addIconSmall"] {
-    qproperty-icon: url(theme:Dark/plus.svg);
-}
-
-* [themeID="removeIconSmall"] {
-    qproperty-icon: url(theme:Dark/trash.svg);
-}
-
-* [themeID="clearIconSmall"] {
-    qproperty-icon: url(theme:Dark/entry-clear.svg);
-}
-
-* [themeID="propertiesIconSmall"] {
-    qproperty-icon: url(theme:Dark/settings/general.svg);
-}
-
-* [themeID="configIconSmall"] {
-    qproperty-icon: url(theme:Dark/settings/general.svg);
-}
-
-* [themeID="menuIconSmall"] {
-    qproperty-icon: url(theme:Dark/dots-vert.svg);
-}
-
-* [themeID="refreshIconSmall"] {
-    qproperty-icon: url(theme:Dark/refresh.svg);
-}
-
-* [themeID="cogsIcon"] {
-    qproperty-icon: url(theme:Dark/cogs.svg);
-}
-
-#sourceInteractButton {
-    qproperty-icon: url(theme:Dark/interact.svg);
-}
-
-* [themeID="upArrowIconSmall"] {
-    qproperty-icon: url(theme:Dark/up.svg);
-}
-
-* [themeID="downArrowIconSmall"] {
-    qproperty-icon: url(theme:Dark/down.svg);
-}
-
-* [themeID="pauseIconSmall"] {
-    qproperty-icon: url(theme:Dark/media-pause.svg);
-}
-
-* [themeID="filtersIcon"] {
-    qproperty-icon: url(theme:Dark/filter.svg);
-}
-
 QToolBarExtension {
     background: palette(button);
     min-width: 12px;
@@ -604,7 +703,8 @@ QToolBarExtension {
 
 /* Tab Widget */
 
-QTabWidget::pane { /* The tab widget frame */
+/* The tab widget frame */
+QTabWidget::pane {
     border-top: 4px solid palette(base);
 }
 
@@ -693,7 +793,7 @@ QComboBox:hover,
 QComboBox:focus,
 QDateTimeEdit:hover,
 QDateTimeEdit:selected {
-    background-color: var(--ctp_surface1);
+    border-color: var(--ctp_overlay0);
 }
 
 QComboBox::drop-down,
@@ -731,7 +831,7 @@ QDateTimeEdit::drop-down:editable {
 QComboBox::down-arrow:editable,
 QDateTimeEdit::down-arrow:editable {
     qproperty-alignment: AlignTop;
-    image: url(theme:Dark/down.svg);
+    image: url(theme:Dark/collapse.svg);
     width: 100%;
 }
 
@@ -795,7 +895,8 @@ QDoubleSpinBox:focus {
 QSpinBox::up-button,
 QDoubleSpinBox::up-button {
     subcontrol-origin: padding;
-    subcontrol-position: top right; /* position at the top right corner */
+    /* position at the top right corner */
+    subcontrol-position: top right;
 
     width: var(--input_height);
     border-left: 1px solid var(--ctp_crust);
@@ -807,7 +908,8 @@ QDoubleSpinBox::up-button {
 QSpinBox::down-button,
 QDoubleSpinBox::down-button {
     subcontrol-origin: padding;
-    subcontrol-position: bottom right; /* position at the top right corner */
+    /* position at the top right corner */
+    subcontrol-position: bottom right;
 
     width: var(--input_height);
     border-left: 1px solid var(--ctp_crust);
@@ -858,9 +960,8 @@ QDoubleSpinBox::down-arrow {
     padding: 2px;
 }
 
-
 /* Controls Dock */
-#controlsDock QPushButton {
+#controlsFrame {
     padding: var(--padding_large);
 }
 
@@ -891,7 +992,6 @@ QDoubleSpinBox::down-arrow {
 #modeSwitch:!hover:!pressed:checked,
 #broadcastButton:!hover:!pressed:checked {
     background: var(--ctp_blue);
-    color: var(--ctp_crust);
 }
 
 /* Primary Control Button Hover Coloring */
@@ -927,7 +1027,7 @@ QToolButton {
 }
 
 QToolButton,
-QPushButton[toolButton="true"] {
+.btn-tool {
     background-color: palette(button);
     padding: var(--padding_base) var(--padding_base);
     margin: 0px var(--spacing_base);
@@ -937,7 +1037,7 @@ QPushButton[toolButton="true"] {
 }
 
 QToolButton:last-child,
-QPushButton[toolButton="true"]:last-child {
+.btn-tool:last-child {
     margin-right: 0px;
 }
 
@@ -952,10 +1052,10 @@ QPushButton:hover {
 
 QToolButton:hover,
 QToolButton:focus,
-QPushButton[toolButton="true"]:hover,
-QPushButton[toolButton="true"]:focus,
-MuteCheckBox::indicator:hover,
-MuteCheckBox::indicator:focus {
+.btn-tool:hover,
+.btn-tool:focus,
+.indicator-mute::indicator:hover,
+.indicator-mute::indicator:focus {
     border-color: var(--ctp_surface1);
     background-color: var(--ctp_surface1);
 }
@@ -973,16 +1073,16 @@ QPushButton:checked:focus {
     background-color: var(--ctp_surface1);
 }
 
-QPushButton:pressed,
-QPushButton:pressed:hover,
-QPushButton[toolButton="true"]:pressed,
-QPushButton[toolButton="true"]:pressed:hover {
+QToolButton:pressed,
+QToolButton:pressed:hover {
     background-color: var(--ctp_crust);
     border-color: var(--ctp_crust);
 }
 
-QToolButton:pressed,
-QToolButton:pressed:hover {
+QPushButton:pressed,
+QPushButton:pressed:hover,
+.btn-tool:pressed,
+.btn-tool:pressed:hover {
     background-color: var(--ctp_crust);
     border-color: var(--ctp_crust);
 }
@@ -993,7 +1093,7 @@ QPushButton:disabled {
 }
 
 QToolButton:disabled,
-QPushButton[toolButton="true"]:disabled {
+.btn-tool:disabled {
     background-color: var(--ctp_crust);
     border-color: transparent;
 }
@@ -1059,13 +1159,15 @@ QSlider::handle {
 QSlider::handle:horizontal {
     height: 10px;
     width: 20px;
-    margin: -3px 0; /* handle is placed by default on the contents rect of the groove. Expand outside the groove */
+    /* Handle is placed by default on the contents rect of the groove. Expand outside the groove */
+    margin: -3px 0;
 }
 
 QSlider::handle:vertical {
     width: 10px;
     height: 20px;
-    margin: 0 -3px; /* handle is placed by default on the contents rect of the groove. Expand outside the groove */
+    /* Handle is placed by default on the contents rect of the groove. Expand outside the groove */
+    margin: 0 -3px;
 }
 
 QSlider::handle:hover {
@@ -1123,7 +1225,7 @@ VolControl #volLabel {
 /* Horizontal Mixer */
 #hMixerScrollArea VolControl {
     padding: 0px var(--padding_xlarge) var(--padding_base);
-    border-bottom: 1px solid palette(window);
+    border-bottom: 1px solid var(--ctp_surface0);
 }
 
 #hMixerScrollArea VolControl QSlider {
@@ -1137,12 +1239,12 @@ VolControl #volLabel {
 
 /* Vertical Mixer */
 #stackedMixerArea QScrollBar:vertical {
-    border-left: 1px solid var(--ctp_overlay0);
+    border-left: 1px solid var(--ctp_surface0);
 }
 
 #vMixerScrollArea VolControl {
     padding: var(--padding_large) 0px var(--padding_base);
-    border-right: 1px solid var(--ctp_overlay0);
+    border-right: 1px solid var(--ctp_surface0);
 }
 
 #vMixerScrollArea VolControl QSlider {
@@ -1174,7 +1276,7 @@ VolControl #volLabel {
     margin-right: var(--padding_xlarge);
 }
 
-#vMixerScrollArea VolControl MuteCheckBox {
+#vMixerScrollArea VolControl .indicator-mute {
     margin-left: var(--padding_xlarge);
 }
 
@@ -1185,7 +1287,6 @@ VolControl {
 VolumeMeter {
     background: transparent;
 }
-
 
 VolumeMeter {
     qproperty-backgroundNominalColor: var(--ctp_green);
@@ -1249,67 +1350,6 @@ QHeaderView::section {
     margin-bottom: 2px;
 }
 
-OBSHotkeyLabel[hotkeyPairHover=true] {
-    color: var(--ctp_blue);
-}
-
-/* Label warning/error */
-
-QLabel#warningLabel {
-    color: var(--ctp_peach);
-    font-weight: bold;
-}
-
-QLabel#errorLabel {
-    color: var(--ctp_maroon);
-    font-weight: bold;
-}
-
-* [themeID="warning"] {
-    color: var(--ctp_peach);
-    font-weight: bold;
-}
-
-* [themeID="error"] {
-    color: var(--ctp_maroon);
-    font-weight: bold;
-}
-
-* [themeID="good"] {
-    color: var(--ctp_green);
-    font-weight: bold;
-}
-
-QFrame [noticeFrame="true"] {
-    background: var(--ctp_crust);
-    border-radius: var(--border_radius);
-    padding: var(--padding_xlarge) var(--padding_large);
-}
-
-QFrame [noticeFrame="true"] QLabel {
-    padding: var(--padding_large) 0px;
-}
-
-/* About dialog */
-
-* [themeID="aboutName"] {
-    font-size: var(--font_heading);
-    font-weight: bold;
-}
-
-* [themeID="aboutVersion"] {
-    font-size: var(--font_large);
-    margin-bottom: 20px;
-}
-
-* [themeID="aboutInfo"] {
-    margin-bottom: 20px;
-}
-
-* [themeID="aboutHLayout"] {
-    background-color: palette(base);
-}
-
 /* Canvas / Preview background color */
 
 OBSQTDisplay {
@@ -1344,7 +1384,7 @@ OBSBasicFilters #widget_2 QPushButton {
 
 /* Preview/Program labels */
 
-* [themeID="previewProgramLabels"] {
+.label-preview-title {
     font-size: var(--font_xlarge);
     font-weight: bold;
     color: var(--ctp_subtext0);
@@ -1366,9 +1406,6 @@ OBSBasicSettings {
 }
 
 /* Checkboxes */
-QCheckBox {
-
-}
 
 QCheckBox::indicator,
 QGroupBox::indicator {
@@ -1411,84 +1448,60 @@ QGroupBox::indicator:unchecked:disabled {
     image: url(theme:Yami/checkbox_unchecked_disabled.svg);
 }
 
-/* Locked CheckBox */
-
-QCheckBox[lockCheckBox=true] {
+/* Icon Checkboxes */
+.checkbox-icon {
     outline: none;
     background: transparent;
     max-width: var(--icon_base);
     max-height: var(--icon_base);
     padding: var(--padding_base);
+    margin-right: var(--spacing_large);
     border: 1px solid transparent;
-    margin-left: var(--spacing_large);
-}
-
-QCheckBox[lockCheckBox=true]::indicator {
-    width: var(--icon_base);
-    height: var(--icon_base);
     border-radius: 4px;
 }
 
-QCheckBox[lockCheckBox=true]::indicator:checked,
-QCheckBox[lockCheckBox=true]::indicator:checked:hover {
+.checkbox-icon::indicator {
+    width: var(--icon_base);
+    height: var(--icon_base);
+}
+
+.checkbox-icon:hover,
+.checkbox-icon:focus {
+    border-color: var(--border_highlight);
+}
+
+/* Locked CheckBox */
+
+.indicator-lock::indicator:checked,
+.indicator-lock::indicator:checked:hover {
     image: url(theme:Dark/locked.svg);
 }
 
-QCheckBox[lockCheckBox=true]::indicator:unchecked,
-QCheckBox[lockCheckBox=true]::indicator:unchecked:hover {
+.indicator-lock::indicator:unchecked,
+.indicator-lock::indicator:unchecked:hover {
     image: url(:res/images/unlocked.svg);
-}
-
-QCheckBox[lockCheckBox=true]:hover,
-QCheckBox[lockCheckBox=true]:focus {
-    border: 1px solid var(--border_highlight);
 }
 
 /* Visibility CheckBox */
 
-QCheckBox[visibilityCheckBox=true] {
-    outline: none;
-    background: transparent;
-    max-width: var(--icon_base);
-    max-height: var(--icon_base);
-    padding: var(--padding_base);
-    border: 1px solid transparent;
-    margin-left: var(--spacing_large);
-}
-
-QCheckBox[visibilityCheckBox=true]::indicator {
-    width: var(--icon_base);
-    height: var(--icon_base);
-    border-radius: 4px;
-}
-
-QCheckBox[visibilityCheckBox=true]::indicator:checked,
-QCheckBox[visibilityCheckBox=true]::indicator:checked:hover {
+.indicator-visibility::indicator:checked,
+.indicator-visibility::indicator:checked:hover {
     image: url(theme:Dark/visible.svg);
 }
 
-QCheckBox[visibilityCheckBox=true]::indicator:unchecked,
-QCheckBox[visibilityCheckBox=true]::indicator:unchecked:hover {
+.indicator-visibility::indicator:unchecked,
+.indicator-visibility::indicator:unchecked:hover {
     image: url(:res/images/invisible.svg);
-}
-
-QCheckBox[visibilityCheckBox=true]:hover,
-QCheckBox[visibilityCheckBox=true]:focus {
-    border: 1px solid var(--border_highlight);
-}
-
-* [themeID="revertIcon"] {
-    qproperty-icon: url(theme:Dark/revert.svg);
 }
 
 /* Mute CheckBox */
 
-MuteCheckBox {
+.indicator-mute {
     outline: none;
 }
 
-MuteCheckBox::indicator,
-MuteCheckBox::indicator:unchecked {
+.indicator-mute::indicator,
+.indicator-mute::indicator:unchecked {
     width: var(--icon_base);
     height: var(--icon_base);
     background-color: palette(button);
@@ -1499,8 +1512,8 @@ MuteCheckBox::indicator:unchecked {
     icon-size: var(--icon_base);
 }
 
-MuteCheckBox::indicator:hover,
-MuteCheckBox::indicator:unchecked:hover {
+.indicator-mute::indicator:hover,
+.indicator-mute::indicator:unchecked:hover {
     background-color: palette(mid);
     padding: var(--padding_base_border) var(--padding_base_border);
     margin: 0px;
@@ -1508,45 +1521,45 @@ MuteCheckBox::indicator:unchecked:hover {
     icon-size: var(--icon_base);
 }
 
-MuteCheckBox::indicator:pressed,
-MuteCheckBox::indicator:pressed:hover {
+.indicator-mute::indicator:pressed,
+.indicator-mute::indicator:pressed:hover {
     background-color: palette(mid);
     border-color: var(--ctp_surface1);
 }
 
-MuteCheckBox::indicator:checked {
+.indicator-mute::indicator:checked {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:indeterminate {
+.indicator-mute::indicator:indeterminate {
     image: url(theme:Dark/unassigned.svg);
 }
 
-MuteCheckBox::indicator:unchecked {
+.indicator-mute::indicator:unchecked {
     image: url(theme:Dark/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:unchecked:hover {
+.indicator-mute::indicator:unchecked:hover {
     image: url(theme:Dark/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:unchecked:focus {
+.indicator-mute::indicator:unchecked:focus {
     image: url(theme:Dark/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:checked:hover {
+.indicator-mute::indicator:checked:hover {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:checked:focus {
+.indicator-mute::indicator:checked:focus {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:checked:disabled {
+.indicator-mute::indicator:checked:disabled {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:unchecked:disabled {
+.indicator-mute::indicator:unchecked:disabled {
     image: url(theme:Dark/settings/audio.svg);
 }
 
@@ -1563,10 +1576,6 @@ OBSHotkeyLabel {
     padding: 4px 0px;
 }
 
-OBSHotkeyLabel[hotkeyPairHover=true] {
-    color: var(--ctp_blue);
-}
-
 OBSHotkeyWidget QPushButton {
     min-width: 16px;
     padding: var(--padding_base);
@@ -1577,36 +1586,14 @@ OBSHotkeyWidget QPushButton {
 
 /* Sources List Group Collapse Checkbox */
 
-QCheckBox[sourceTreeSubItem=true] {
-    background: transparent;
-    outline: none;
-    padding: 1px;
-    min-width: var(--icon_base);
-    min-height: var(--icon_base);
-}
-
-QCheckBox[sourceTreeSubItem=true]::indicator {
-    width: var(--icon_base);
-    height: var(--icon_base);
-    padding: 0px;
-    border: 1px solid transparent;
-    border-radius: 4px;
-    margin-left: -1px;
-}
-
-QCheckBox[sourceTreeSubItem=true]::indicator:checked,
-QCheckBox[sourceTreeSubItem=true]::indicator:checked:hover {
+.indicator-expand::indicator:checked,
+.indicator-expand::indicator:checked:hover {
     image: url(theme:Dark/expand.svg);
 }
 
-QCheckBox[sourceTreeSubItem=true]::indicator:unchecked,
-QCheckBox[sourceTreeSubItem=true]::indicator:unchecked:hover {
+.indicator-expand::indicator:unchecked,
+.indicator-expand::indicator:unchecked:hover {
     image: url(theme:Dark/collapse.svg);
-}
-
-QCheckBox[sourceTreeSubItem=true]::indicator:hover,
-QCheckBox[sourceTreeSubItem=true]::indicator:focus {
-    border: 1px solid var(--border_highlight);
 }
 
 /* Source Icons */
@@ -1637,79 +1624,47 @@ SceneTree {
     qproperty-gridItemHeight: var(--input_height_base);
 }
 
-*[gridMode="true"] SceneTree::item {
+.list-grid SceneTree::item {
     color: palette(text);
     background-color: palette(button);
     border-radius: var(--border_radius);
     margin: var(--spacing_base);
 }
 
-*[gridMode="true"] SceneTree::item:selected {
+.list-grid SceneTree::item:selected {
     background-color: var(--ctp_surface1);
 }
 
-*[gridMode="true"] SceneTree::item:checked {
+.list-grid SceneTree::item:checked {
     background-color: var(--ctp_surface1);
 }
 
-*[gridMode="true"] SceneTree::item:hover {
+.list-grid SceneTree::item:hover {
     background-color: var(--ctp_surface1);
 }
 
-*[gridMode="true"] SceneTree::item:selected:hover {
+.list-grid SceneTree::item:selected:hover {
     background-color: var(--ctp_surface1);
-}
-
-/* Save icon */
-
-* [themeID="replayIconSmall"] {
-    qproperty-icon: url(theme:Dark/save.svg);
 }
 
 /* Studio Mode T-Bar */
 
-QSlider[themeID="tBarSlider"] {
+.slider-tbar {
     height: 24px;
 }
 
-QSlider::groove:horizontal[themeID="tBarSlider"] {
+.slider-tbar::groove:horizontal {
     height: 8px;
 }
 
-QSlider::sub-page:horizontal[themeID="tBarSlider"] {
+.slider-tbar::sub-page:horizontal {
     background: var(--ctp_blue);
 }
 
-QSlider::handle:horizontal[themeID="tBarSlider"] {
+.slider-tbar::handle:horizontal {
     width: 12px;
     height: 24px;
     margin: -24px 0px;
-}
-
-/* Media icons */
-
-* [themeID="playIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_play.svg);
-}
-
-* [themeID="pauseIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_pause.svg);
-}
-
-* [themeID="restartIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_restart.svg);
-}
-
-* [themeID="stopIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_stop.svg);
-}
-
-* [themeID="nextIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_next.svg);
-}
-
-* [themeID="previousIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_previous.svg);
 }
 
 /* YouTube Integration */
@@ -1729,12 +1684,12 @@ OBSYoutubeActions {
     background-color: var(--ctp_surface1);
 }
 
-#ytEventList QLabel[isSelectedEvent=true] {
+#ytEventList .row-selected {
     background-color: var(--ctp_surface1);
     border: none;
 }
 
-#ytEventList QLabel[isSelectedEvent=true]:hover {
+#ytEventList .row-selected:hover {
     background-color: var(--ctp_blue);
     color: palette(text);
 }
@@ -1774,7 +1729,7 @@ QCalendarWidget QToolButton {
 }
 
 QCalendarWidget #qt_calendar_prevmonth {
-    padding: 2px;
+    padding: var(--padding_small);
     qproperty-icon: url(theme:Dark/left.svg);
     icon-size: var(--icon_base);
 }
@@ -1795,8 +1750,7 @@ QCalendarWidget QToolButton:pressed {
 }
 
 /* Month Dropdown Menu */
-QCalendarWidget QMenu {
-}
+QCalendarWidget QMenu {}
 
 /* Year spinbox */
 QCalendarWidget QSpinBox {
@@ -1807,13 +1761,32 @@ QCalendarWidget QSpinBox {
     padding: var(--padding_base) 16px;
 }
 
-QCalendarWidget QSpinBox::up-button { subcontrol-origin: border; subcontrol-position: top right; width: 16px; }
-QCalendarWidget QSpinBox::down-button {subcontrol-origin: border; subcontrol-position: bottom right; width: 16px;}
-QCalendarWidget QSpinBox::up-arrow { width: 10px; height: 10px; }
-QCalendarWidget QSpinBox::down-arrow { width: 10px; height: 10px; }
+QCalendarWidget QSpinBox::up-button {
+    subcontrol-origin: border;
+    subcontrol-position: top right;
+    width: 16px;
+}
+
+QCalendarWidget QSpinBox::down-button {
+    subcontrol-origin: border;
+    subcontrol-position: bottom right;
+    width: 16px;
+}
+
+QCalendarWidget QSpinBox::up-arrow {
+    width: 10px;
+    height: 10px;
+}
+
+QCalendarWidget QSpinBox::down-arrow {
+    width: 10px;
+    height: 10px;
+}
 
 /* Days of the Week Bar */
-QCalendarWidget QWidget { alternate-background-color: palette(mid); }
+QCalendarWidget QWidget {
+    alternate-background-color: palette(mid);
+}
 
 QCalendarWidget QAbstractItemView:enabled {
     background-color: palette(base);
@@ -1844,4 +1817,51 @@ OBSBasicStats {
 /* Advanced audio dialog */
 OBSBasicAdvAudio #scrollAreaWidgetContents {
     background: palette(dark);
+}
+
+#previewScalePercent,
+#previewScalingMode {
+    background: transparent;
+    color: var(--ctp_text);
+    font-size: var(--font_xsmall);
+    height: 14px;
+    max-height: 14px;
+    padding: 0px var(--padding_xlarge);
+    margin: 0;
+    border: none;
+    border-radius: 0;
+}
+
+#previewXContainer {
+    border: 1px solid var(--ctp_base);
+}
+
+#previewScalingMode {
+    border: 1px solid var(--ctp_base);
+}
+
+#previewScalingMode:hover,
+#previewScalingMode:focus {
+    border-color: var(--ctp_base);
+}
+
+#previewXScrollBar,
+#previewYScrollBar {
+    background: transparent;
+    border: 1px solid var(--ctp_base);
+    border-radius: 0;
+}
+
+#previewXScrollBar {
+    border-left: none;
+    height: 16px;
+}
+
+#previewXScrollBar::handle,
+#previewYScrollBar::handle {
+    margin: 3px;
+}
+
+#previewYScrollBar {
+    width: 16px;
 }

--- a/themes/Catppuccin_Frappe.ovt
+++ b/themes/Catppuccin_Frappe.ovt
@@ -42,6 +42,94 @@ VolumeMeter {
     qproperty-foregroundErrorColor: #db4346;
 }
 
+/* Icon Overrides */
+
+.icon-plus {
+    qproperty-icon: url(theme:Dark/plus.svg);
+}
+
+.icon-minus {
+    qproperty-icon: url(theme:Dark/minus.svg);
+}
+
+.icon-trash {
+    qproperty-icon: url(theme:Dark/trash.svg);
+}
+
+.icon-clear {
+    qproperty-icon: url(theme:Dark/entry-clear.svg);
+}
+
+.icon-gear {
+    qproperty-icon: url(theme:Dark/settings/general.svg);
+}
+
+.icon-dots-vert {
+    qproperty-icon: url(theme:Dark/dots-vert.svg);
+}
+
+.icon-refresh {
+    qproperty-icon: url(theme:Dark/refresh.svg);
+}
+
+.icon-cogs {
+    qproperty-icon: url(theme:Dark/cogs.svg);
+}
+
+.icon-touch {
+    qproperty-icon: url(theme:Dark/interact.svg);
+}
+
+.icon-up {
+    qproperty-icon: url(theme:Dark/up.svg);
+}
+
+.icon-down {
+    qproperty-icon: url(theme:Dark/down.svg);
+}
+
+.icon-pause {
+    qproperty-icon: url(theme:Dark/media-pause.svg);
+}
+
+.icon-filter {
+    qproperty-icon: url(theme:Dark/filter.svg);
+}
+
+.icon-revert {
+    qproperty-icon: url(theme:Dark/revert.svg);
+}
+
+.icon-save {
+    qproperty-icon: url(theme:Dark/save.svg);
+}
+
+/* Media icons */
+
+.icon-media-play {
+    qproperty-icon: url(theme:Dark/media/media_play.svg);
+}
+
+.icon-media-pause {
+    qproperty-icon: url(theme:Dark/media/media_pause.svg);
+}
+
+.icon-media-restart {
+    qproperty-icon: url(theme:Dark/media/media_restart.svg);
+}
+
+.icon-media-stop {
+    qproperty-icon: url(theme:Dark/media/media_stop.svg);
+}
+
+.icon-media-next {
+    qproperty-icon: url(theme:Dark/media/media_next.svg);
+}
+
+.icon-media-prev {
+    qproperty-icon: url(theme:Dark/media/media_previous.svg);
+}
+
 /* Context Menu */
 QMenu::right-arrow {
     image: url(theme:Dark/expand.svg);
@@ -63,58 +151,6 @@ QPushButton#sourceFiltersButton {
 }
 
 /* Scenes and Sources toolbar */
-* [themeID="addIconSmall"] {
-    qproperty-icon: url(theme:Dark/plus.svg);
-}
-
-* [themeID="removeIconSmall"] {
-    qproperty-icon: url(theme:Dark/trash.svg);
-}
-
-* [themeID="clearIconSmall"] {
-    qproperty-icon: url(theme:Dark/entry-clear.svg);
-}
-
-* [themeID="propertiesIconSmall"] {
-    qproperty-icon: url(theme:Dark/settings/general.svg);
-}
-
-* [themeID="configIconSmall"] {
-    qproperty-icon: url(theme:Dark/settings/general.svg);
-}
-
-* [themeID="menuIconSmall"] {
-    qproperty-icon: url(theme:Dark/dots-vert.svg);
-}
-
-* [themeID="refreshIconSmall"] {
-    qproperty-icon: url(theme:Dark/refresh.svg);
-}
-
-* [themeID="cogsIcon"] {
-    qproperty-icon: url(theme:Dark/cogs.svg);
-}
-
-#sourceInteractButton {
-    qproperty-icon: url(theme:Dark/interact.svg);
-}
-
-* [themeID="upArrowIconSmall"] {
-    qproperty-icon: url(theme:Dark/up.svg);
-}
-
-* [themeID="downArrowIconSmall"] {
-    qproperty-icon: url(theme:Dark/down.svg);
-}
-
-* [themeID="pauseIconSmall"] {
-    qproperty-icon: url(theme:Dark/media-pause.svg);
-}
-
-* [themeID="filtersIcon"] {
-    qproperty-icon: url(theme:Dark/filter.svg);
-}
-
 QToolBarExtension {
     qproperty-icon: url(theme:Dark/dots-vert.svg);
 }
@@ -127,7 +163,7 @@ QDateTimeEdit::down-arrow {
 
 QComboBox::down-arrow:editable,
 QDateTimeEdit::down-arrow:editable {
-    image: url(theme:Dark/down.svg);
+    image: url(theme:Dark/collapse.svg);
 }
 
 /* Spinbox and doubleSpinbox */
@@ -187,66 +223,62 @@ QGroupBox::indicator:checked:disabled {
 }
 
 /* Locked CheckBox */
-QCheckBox[lockCheckBox=true]::indicator:checked,
-QCheckBox[lockCheckBox=true]::indicator:checked:hover {
+.indicator-lock::indicator:checked,
+.indicator-lock::indicator:checked:hover {
     image: url(theme:Dark/locked.svg);
 }
 
 /* Visibility CheckBox */
-QCheckBox[visibilityCheckBox=true]::indicator:checked,
-QCheckBox[visibilityCheckBox=true]::indicator:checked:hover {
+.indicator-visibility::indicator:checked,
+.indicator-visibility::indicator:checked:hover {
     image: url(theme:Dark/visible.svg);
 }
 
-* [themeID="revertIcon"] {
-    qproperty-icon: url(theme:Dark/revert.svg);
-}
-
 /* Mute CheckBox */
-MuteCheckBox::indicator:checked {
+.indicator-mute::indicator:checked {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:indeterminate {
+.indicator-mute::indicator:indeterminate {
     image: url(theme:Dark/unassigned.svg);
 }
 
-MuteCheckBox::indicator:unchecked {
+.indicator-mute::indicator:unchecked {
     image: url(theme:Dark/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:unchecked:hover {
+.indicator-mute::indicator:unchecked:hover {
     image: url(theme:Dark/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:unchecked:focus {
+.indicator-mute::indicator:unchecked:focus {
     image: url(theme:Dark/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:checked:hover {
+.indicator-mute::indicator:checked:hover {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:checked:focus {
+.indicator-mute::indicator:checked:focus {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:checked:disabled {
+.indicator-mute::indicator:checked:disabled {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:unchecked:disabled {
+.indicator-mute::indicator:unchecked:disabled {
     image: url(theme:Dark/settings/audio.svg);
 }
 
 /* Sources List Group Collapse Checkbox */
-QCheckBox[sourceTreeSubItem=true]::indicator:checked,
-QCheckBox[sourceTreeSubItem=true]::indicator:checked:hover {
+.indicator-expand::indicator:checked,
+.indicator-expand::indicator:checked:hover {
     image: url(theme:Dark/expand.svg);
 }
 
-QCheckBox[sourceTreeSubItem=true]::indicator:unchecked,
-QCheckBox[sourceTreeSubItem=true]::indicator:unchecked:hover {
+.indicator-expand::indicator:unchecked,
+.indicator-expand::indicator:unchecked:hover {
     image: url(theme:Dark/collapse.svg);
 }
 
@@ -268,36 +300,6 @@ OBSBasic {
     qproperty-sceneIcon: url(theme:Dark/sources/scene.svg);
     qproperty-defaultIcon: url(theme:Dark/sources/default.svg);
     qproperty-audioProcessOutputIcon: url(theme:Dark/sources/windowaudio.svg);
-}
-
-/* Save icon */
-* [themeID="replayIconSmall"] {
-    qproperty-icon: url(theme:Dark/save.svg);
-}
-
-/* Media icons */
-* [themeID="playIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_play.svg);
-}
-
-* [themeID="pauseIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_pause.svg);
-}
-
-* [themeID="restartIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_restart.svg);
-}
-
-* [themeID="stopIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_stop.svg);
-}
-
-* [themeID="nextIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_next.svg);
-}
-
-* [themeID="previousIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_previous.svg);
 }
 
 /* YouTube Integration */

--- a/themes/Catppuccin_Latte.ovt
+++ b/themes/Catppuccin_Latte.ovt
@@ -42,6 +42,94 @@ VolumeMeter {
     qproperty-foregroundErrorColor: #f13d64;
 }
 
+/* Icon Overrides */
+
+.icon-plus {
+    qproperty-icon: url(theme:Light/plus.svg);
+}
+
+.icon-minus {
+    qproperty-icon: url(theme:Light/minus.svg);
+}
+
+.icon-trash {
+    qproperty-icon: url(theme:Light/trash.svg);
+}
+
+.icon-clear {
+    qproperty-icon: url(theme:Light/entry-clear.svg);
+}
+
+.icon-gear {
+    qproperty-icon: url(theme:Light/settings/general.svg);
+}
+
+.icon-dots-vert {
+    qproperty-icon: url(theme:Light/dots-vert.svg);
+}
+
+.icon-refresh {
+    qproperty-icon: url(theme:Light/refresh.svg);
+}
+
+.icon-cogs {
+    qproperty-icon: url(theme:Light/cogs.svg);
+}
+
+.icon-touch {
+    qproperty-icon: url(theme:Light/interact.svg);
+}
+
+.icon-up {
+    qproperty-icon: url(theme:Light/up.svg);
+}
+
+.icon-down {
+    qproperty-icon: url(theme:Light/down.svg);
+}
+
+.icon-pause {
+    qproperty-icon: url(theme:Light/media-pause.svg);
+}
+
+.icon-filter {
+    qproperty-icon: url(theme:Light/filter.svg);
+}
+
+.icon-revert {
+    qproperty-icon: url(theme:Light/revert.svg);
+}
+
+.icon-save {
+    qproperty-icon: url(theme:Light/save.svg);
+}
+
+/* Media icons */
+
+.icon-media-play {
+    qproperty-icon: url(theme:Light/media/media_play.svg);
+}
+
+.icon-media-pause {
+    qproperty-icon: url(theme:Light/media/media_pause.svg);
+}
+
+.icon-media-restart {
+    qproperty-icon: url(theme:Light/media/media_restart.svg);
+}
+
+.icon-media-stop {
+    qproperty-icon: url(theme:Light/media/media_stop.svg);
+}
+
+.icon-media-next {
+    qproperty-icon: url(theme:Light/media/media_next.svg);
+}
+
+.icon-media-prev {
+    qproperty-icon: url(theme:Light/media/media_previous.svg);
+}
+
 /* Context Menu */
 QMenu::right-arrow {
     image: url(theme:Light/expand.svg);
@@ -63,58 +151,6 @@ QPushButton#sourceFiltersButton {
 }
 
 /* Scenes and Sources toolbar */
-* [themeID="addIconSmall"] {
-    qproperty-icon: url(theme:Light/plus.svg);
-}
-
-* [themeID="removeIconSmall"] {
-    qproperty-icon: url(theme:Light/trash.svg);
-}
-
-* [themeID="clearIconSmall"] {
-    qproperty-icon: url(theme:Light/entry-clear.svg);
-}
-
-* [themeID="propertiesIconSmall"] {
-    qproperty-icon: url(theme:Light/settings/general.svg);
-}
-
-* [themeID="configIconSmall"] {
-    qproperty-icon: url(theme:Light/settings/general.svg);
-}
-
-* [themeID="menuIconSmall"] {
-    qproperty-icon: url(theme:Light/dots-vert.svg);
-}
-
-* [themeID="refreshIconSmall"] {
-    qproperty-icon: url(theme:Light/refresh.svg);
-}
-
-* [themeID="cogsIcon"] {
-    qproperty-icon: url(theme:Light/cogs.svg);
-}
-
-#sourceInteractButton {
-    qproperty-icon: url(theme:Light/interact.svg);
-}
-
-* [themeID="upArrowIconSmall"] {
-    qproperty-icon: url(theme:Light/up.svg);
-}
-
-* [themeID="downArrowIconSmall"] {
-    qproperty-icon: url(theme:Light/down.svg);
-}
-
-* [themeID="pauseIconSmall"] {
-    qproperty-icon: url(theme:Light/media-pause.svg);
-}
-
-* [themeID="filtersIcon"] {
-    qproperty-icon: url(theme:Light/filter.svg);
-}
-
 QToolBarExtension {
     qproperty-icon: url(theme:Light/dots-vert.svg);
 }
@@ -127,7 +163,7 @@ QDateTimeEdit::down-arrow {
 
 QComboBox::down-arrow:editable,
 QDateTimeEdit::down-arrow:editable {
-    image: url(theme:Light/down.svg);
+    image: url(theme:Light/collapse.svg);
 }
 
 /* Spinbox and doubleSpinbox */
@@ -187,66 +223,62 @@ QGroupBox::indicator:checked:disabled {
 }
 
 /* Locked CheckBox */
-QCheckBox[lockCheckBox=true]::indicator:checked,
-QCheckBox[lockCheckBox=true]::indicator:checked:hover {
+.indicator-lock::indicator:checked,
+.indicator-lock::indicator:checked:hover {
     image: url(theme:Light/locked.svg);
 }
 
 /* Visibility CheckBox */
-QCheckBox[visibilityCheckBox=true]::indicator:checked,
-QCheckBox[visibilityCheckBox=true]::indicator:checked:hover {
+.indicator-visibility::indicator:checked,
+.indicator-visibility::indicator:checked:hover {
     image: url(theme:Light/visible.svg);
 }
 
-* [themeID="revertIcon"] {
-    qproperty-icon: url(theme:Light/revert.svg);
-}
-
 /* Mute CheckBox */
-MuteCheckBox::indicator:checked {
+.indicator-mute::indicator:checked {
     image: url(theme:Light/mute.svg);
 }
 
-MuteCheckBox::indicator:indeterminate {
+.indicator-mute::indicator:indeterminate {
     image: url(theme:Light/unassigned.svg);
 }
 
-MuteCheckBox::indicator:unchecked {
+.indicator-mute::indicator:unchecked {
     image: url(theme:Light/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:unchecked:hover {
+.indicator-mute::indicator:unchecked:hover {
     image: url(theme:Light/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:unchecked:focus {
+.indicator-mute::indicator:unchecked:focus {
     image: url(theme:Light/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:checked:hover {
+.indicator-mute::indicator:checked:hover {
     image: url(theme:Light/mute.svg);
 }
 
-MuteCheckBox::indicator:checked:focus {
+.indicator-mute::indicator:checked:focus {
     image: url(theme:Light/mute.svg);
 }
 
-MuteCheckBox::indicator:checked:disabled {
+.indicator-mute::indicator:checked:disabled {
     image: url(theme:Light/mute.svg);
 }
 
-MuteCheckBox::indicator:unchecked:disabled {
+.indicator-mute::indicator:unchecked:disabled {
     image: url(theme:Light/settings/audio.svg);
 }
 
 /* Sources List Group Collapse Checkbox */
-QCheckBox[sourceTreeSubItem=true]::indicator:checked,
-QCheckBox[sourceTreeSubItem=true]::indicator:checked:hover {
+.indicator-expand::indicator:checked,
+.indicator-expand::indicator:checked:hover {
     image: url(theme:Light/expand.svg);
 }
 
-QCheckBox[sourceTreeSubItem=true]::indicator:unchecked,
-QCheckBox[sourceTreeSubItem=true]::indicator:unchecked:hover {
+.indicator-expand::indicator:unchecked,
+.indicator-expand::indicator:unchecked:hover {
     image: url(theme:Light/collapse.svg);
 }
 
@@ -268,36 +300,6 @@ OBSBasic {
     qproperty-sceneIcon: url(theme:Light/sources/scene.svg);
     qproperty-defaultIcon: url(theme:Light/sources/default.svg);
     qproperty-audioProcessOutputIcon: url(theme:Light/sources/windowaudio.svg);
-}
-
-/* Save icon */
-* [themeID="replayIconSmall"] {
-    qproperty-icon: url(theme:Light/save.svg);
-}
-
-/* Media icons */
-* [themeID="playIcon"] {
-    qproperty-icon: url(theme:Light/media/media_play.svg);
-}
-
-* [themeID="pauseIcon"] {
-    qproperty-icon: url(theme:Light/media/media_pause.svg);
-}
-
-* [themeID="restartIcon"] {
-    qproperty-icon: url(theme:Light/media/media_restart.svg);
-}
-
-* [themeID="stopIcon"] {
-    qproperty-icon: url(theme:Light/media/media_stop.svg);
-}
-
-* [themeID="nextIcon"] {
-    qproperty-icon: url(theme:Light/media/media_next.svg);
-}
-
-* [themeID="previousIcon"] {
-    qproperty-icon: url(theme:Light/media/media_previous.svg);
 }
 
 /* YouTube Integration */

--- a/themes/Catppuccin_Macchiato.ovt
+++ b/themes/Catppuccin_Macchiato.ovt
@@ -42,6 +42,94 @@ VolumeMeter {
     qproperty-foregroundErrorColor: #e3455d;
 }
 
+/* Icon Overrides */
+
+.icon-plus {
+    qproperty-icon: url(theme:Dark/plus.svg);
+}
+
+.icon-minus {
+    qproperty-icon: url(theme:Dark/minus.svg);
+}
+
+.icon-trash {
+    qproperty-icon: url(theme:Dark/trash.svg);
+}
+
+.icon-clear {
+    qproperty-icon: url(theme:Dark/entry-clear.svg);
+}
+
+.icon-gear {
+    qproperty-icon: url(theme:Dark/settings/general.svg);
+}
+
+.icon-dots-vert {
+    qproperty-icon: url(theme:Dark/dots-vert.svg);
+}
+
+.icon-refresh {
+    qproperty-icon: url(theme:Dark/refresh.svg);
+}
+
+.icon-cogs {
+    qproperty-icon: url(theme:Dark/cogs.svg);
+}
+
+.icon-touch {
+    qproperty-icon: url(theme:Dark/interact.svg);
+}
+
+.icon-up {
+    qproperty-icon: url(theme:Dark/up.svg);
+}
+
+.icon-down {
+    qproperty-icon: url(theme:Dark/down.svg);
+}
+
+.icon-pause {
+    qproperty-icon: url(theme:Dark/media-pause.svg);
+}
+
+.icon-filter {
+    qproperty-icon: url(theme:Dark/filter.svg);
+}
+
+.icon-revert {
+    qproperty-icon: url(theme:Dark/revert.svg);
+}
+
+.icon-save {
+    qproperty-icon: url(theme:Dark/save.svg);
+}
+
+/* Media icons */
+
+.icon-media-play {
+    qproperty-icon: url(theme:Dark/media/media_play.svg);
+}
+
+.icon-media-pause {
+    qproperty-icon: url(theme:Dark/media/media_pause.svg);
+}
+
+.icon-media-restart {
+    qproperty-icon: url(theme:Dark/media/media_restart.svg);
+}
+
+.icon-media-stop {
+    qproperty-icon: url(theme:Dark/media/media_stop.svg);
+}
+
+.icon-media-next {
+    qproperty-icon: url(theme:Dark/media/media_next.svg);
+}
+
+.icon-media-prev {
+    qproperty-icon: url(theme:Dark/media/media_previous.svg);
+}
+
 /* Context Menu */
 QMenu::right-arrow {
     image: url(theme:Dark/expand.svg);
@@ -63,58 +151,6 @@ QPushButton#sourceFiltersButton {
 }
 
 /* Scenes and Sources toolbar */
-* [themeID="addIconSmall"] {
-    qproperty-icon: url(theme:Dark/plus.svg);
-}
-
-* [themeID="removeIconSmall"] {
-    qproperty-icon: url(theme:Dark/trash.svg);
-}
-
-* [themeID="clearIconSmall"] {
-    qproperty-icon: url(theme:Dark/entry-clear.svg);
-}
-
-* [themeID="propertiesIconSmall"] {
-    qproperty-icon: url(theme:Dark/settings/general.svg);
-}
-
-* [themeID="configIconSmall"] {
-    qproperty-icon: url(theme:Dark/settings/general.svg);
-}
-
-* [themeID="menuIconSmall"] {
-    qproperty-icon: url(theme:Dark/dots-vert.svg);
-}
-
-* [themeID="refreshIconSmall"] {
-    qproperty-icon: url(theme:Dark/refresh.svg);
-}
-
-* [themeID="cogsIcon"] {
-    qproperty-icon: url(theme:Dark/cogs.svg);
-}
-
-#sourceInteractButton {
-    qproperty-icon: url(theme:Dark/interact.svg);
-}
-
-* [themeID="upArrowIconSmall"] {
-    qproperty-icon: url(theme:Dark/up.svg);
-}
-
-* [themeID="downArrowIconSmall"] {
-    qproperty-icon: url(theme:Dark/down.svg);
-}
-
-* [themeID="pauseIconSmall"] {
-    qproperty-icon: url(theme:Dark/media-pause.svg);
-}
-
-* [themeID="filtersIcon"] {
-    qproperty-icon: url(theme:Dark/filter.svg);
-}
-
 QToolBarExtension {
     qproperty-icon: url(theme:Dark/dots-vert.svg);
 }
@@ -127,7 +163,7 @@ QDateTimeEdit::down-arrow {
 
 QComboBox::down-arrow:editable,
 QDateTimeEdit::down-arrow:editable {
-    image: url(theme:Dark/down.svg);
+    image: url(theme:Dark/collapse.svg);
 }
 
 /* Spinbox and doubleSpinbox */
@@ -187,66 +223,62 @@ QGroupBox::indicator:checked:disabled {
 }
 
 /* Locked CheckBox */
-QCheckBox[lockCheckBox=true]::indicator:checked,
-QCheckBox[lockCheckBox=true]::indicator:checked:hover {
+.indicator-lock::indicator:checked,
+.indicator-lock::indicator:checked:hover {
     image: url(theme:Dark/locked.svg);
 }
 
 /* Visibility CheckBox */
-QCheckBox[visibilityCheckBox=true]::indicator:checked,
-QCheckBox[visibilityCheckBox=true]::indicator:checked:hover {
+.indicator-visibility::indicator:checked,
+.indicator-visibility::indicator:checked:hover {
     image: url(theme:Dark/visible.svg);
 }
 
-* [themeID="revertIcon"] {
-    qproperty-icon: url(theme:Dark/revert.svg);
-}
-
 /* Mute CheckBox */
-MuteCheckBox::indicator:checked {
+.indicator-mute::indicator:checked {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:indeterminate {
+.indicator-mute::indicator:indeterminate {
     image: url(theme:Dark/unassigned.svg);
 }
 
-MuteCheckBox::indicator:unchecked {
+.indicator-mute::indicator:unchecked {
     image: url(theme:Dark/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:unchecked:hover {
+.indicator-mute::indicator:unchecked:hover {
     image: url(theme:Dark/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:unchecked:focus {
+.indicator-mute::indicator:unchecked:focus {
     image: url(theme:Dark/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:checked:hover {
+.indicator-mute::indicator:checked:hover {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:checked:focus {
+.indicator-mute::indicator:checked:focus {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:checked:disabled {
+.indicator-mute::indicator:checked:disabled {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:unchecked:disabled {
+.indicator-mute::indicator:unchecked:disabled {
     image: url(theme:Dark/settings/audio.svg);
 }
 
 /* Sources List Group Collapse Checkbox */
-QCheckBox[sourceTreeSubItem=true]::indicator:checked,
-QCheckBox[sourceTreeSubItem=true]::indicator:checked:hover {
+.indicator-expand::indicator:checked,
+.indicator-expand::indicator:checked:hover {
     image: url(theme:Dark/expand.svg);
 }
 
-QCheckBox[sourceTreeSubItem=true]::indicator:unchecked,
-QCheckBox[sourceTreeSubItem=true]::indicator:unchecked:hover {
+.indicator-expand::indicator:unchecked,
+.indicator-expand::indicator:unchecked:hover {
     image: url(theme:Dark/collapse.svg);
 }
 
@@ -268,36 +300,6 @@ OBSBasic {
     qproperty-sceneIcon: url(theme:Dark/sources/scene.svg);
     qproperty-defaultIcon: url(theme:Dark/sources/default.svg);
     qproperty-audioProcessOutputIcon: url(theme:Dark/sources/windowaudio.svg);
-}
-
-/* Save icon */
-* [themeID="replayIconSmall"] {
-    qproperty-icon: url(theme:Dark/save.svg);
-}
-
-/* Media icons */
-* [themeID="playIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_play.svg);
-}
-
-* [themeID="pauseIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_pause.svg);
-}
-
-* [themeID="restartIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_restart.svg);
-}
-
-* [themeID="stopIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_stop.svg);
-}
-
-* [themeID="nextIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_next.svg);
-}
-
-* [themeID="previousIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_previous.svg);
 }
 
 /* YouTube Integration */

--- a/themes/Catppuccin_Mocha.ovt
+++ b/themes/Catppuccin_Mocha.ovt
@@ -42,6 +42,94 @@ VolumeMeter {
     qproperty-foregroundErrorColor: #ec4675;
 }
 
+/* Icon Overrides */
+
+.icon-plus {
+    qproperty-icon: url(theme:Dark/plus.svg);
+}
+
+.icon-minus {
+    qproperty-icon: url(theme:Dark/minus.svg);
+}
+
+.icon-trash {
+    qproperty-icon: url(theme:Dark/trash.svg);
+}
+
+.icon-clear {
+    qproperty-icon: url(theme:Dark/entry-clear.svg);
+}
+
+.icon-gear {
+    qproperty-icon: url(theme:Dark/settings/general.svg);
+}
+
+.icon-dots-vert {
+    qproperty-icon: url(theme:Dark/dots-vert.svg);
+}
+
+.icon-refresh {
+    qproperty-icon: url(theme:Dark/refresh.svg);
+}
+
+.icon-cogs {
+    qproperty-icon: url(theme:Dark/cogs.svg);
+}
+
+.icon-touch {
+    qproperty-icon: url(theme:Dark/interact.svg);
+}
+
+.icon-up {
+    qproperty-icon: url(theme:Dark/up.svg);
+}
+
+.icon-down {
+    qproperty-icon: url(theme:Dark/down.svg);
+}
+
+.icon-pause {
+    qproperty-icon: url(theme:Dark/media-pause.svg);
+}
+
+.icon-filter {
+    qproperty-icon: url(theme:Dark/filter.svg);
+}
+
+.icon-revert {
+    qproperty-icon: url(theme:Dark/revert.svg);
+}
+
+.icon-save {
+    qproperty-icon: url(theme:Dark/save.svg);
+}
+
+/* Media icons */
+
+.icon-media-play {
+    qproperty-icon: url(theme:Dark/media/media_play.svg);
+}
+
+.icon-media-pause {
+    qproperty-icon: url(theme:Dark/media/media_pause.svg);
+}
+
+.icon-media-restart {
+    qproperty-icon: url(theme:Dark/media/media_restart.svg);
+}
+
+.icon-media-stop {
+    qproperty-icon: url(theme:Dark/media/media_stop.svg);
+}
+
+.icon-media-next {
+    qproperty-icon: url(theme:Dark/media/media_next.svg);
+}
+
+.icon-media-prev {
+    qproperty-icon: url(theme:Dark/media/media_previous.svg);
+}
+
 /* Context Menu */
 QMenu::right-arrow {
     image: url(theme:Dark/expand.svg);
@@ -63,58 +151,6 @@ QPushButton#sourceFiltersButton {
 }
 
 /* Scenes and Sources toolbar */
-* [themeID="addIconSmall"] {
-    qproperty-icon: url(theme:Dark/plus.svg);
-}
-
-* [themeID="removeIconSmall"] {
-    qproperty-icon: url(theme:Dark/trash.svg);
-}
-
-* [themeID="clearIconSmall"] {
-    qproperty-icon: url(theme:Dark/entry-clear.svg);
-}
-
-* [themeID="propertiesIconSmall"] {
-    qproperty-icon: url(theme:Dark/settings/general.svg);
-}
-
-* [themeID="configIconSmall"] {
-    qproperty-icon: url(theme:Dark/settings/general.svg);
-}
-
-* [themeID="menuIconSmall"] {
-    qproperty-icon: url(theme:Dark/dots-vert.svg);
-}
-
-* [themeID="refreshIconSmall"] {
-    qproperty-icon: url(theme:Dark/refresh.svg);
-}
-
-* [themeID="cogsIcon"] {
-    qproperty-icon: url(theme:Dark/cogs.svg);
-}
-
-#sourceInteractButton {
-    qproperty-icon: url(theme:Dark/interact.svg);
-}
-
-* [themeID="upArrowIconSmall"] {
-    qproperty-icon: url(theme:Dark/up.svg);
-}
-
-* [themeID="downArrowIconSmall"] {
-    qproperty-icon: url(theme:Dark/down.svg);
-}
-
-* [themeID="pauseIconSmall"] {
-    qproperty-icon: url(theme:Dark/media-pause.svg);
-}
-
-* [themeID="filtersIcon"] {
-    qproperty-icon: url(theme:Dark/filter.svg);
-}
-
 QToolBarExtension {
     qproperty-icon: url(theme:Dark/dots-vert.svg);
 }
@@ -127,7 +163,7 @@ QDateTimeEdit::down-arrow {
 
 QComboBox::down-arrow:editable,
 QDateTimeEdit::down-arrow:editable {
-    image: url(theme:Dark/down.svg);
+    image: url(theme:Dark/collapse.svg);
 }
 
 /* Spinbox and doubleSpinbox */
@@ -187,66 +223,62 @@ QGroupBox::indicator:checked:disabled {
 }
 
 /* Locked CheckBox */
-QCheckBox[lockCheckBox=true]::indicator:checked,
-QCheckBox[lockCheckBox=true]::indicator:checked:hover {
+.indicator-lock::indicator:checked,
+.indicator-lock::indicator:checked:hover {
     image: url(theme:Dark/locked.svg);
 }
 
 /* Visibility CheckBox */
-QCheckBox[visibilityCheckBox=true]::indicator:checked,
-QCheckBox[visibilityCheckBox=true]::indicator:checked:hover {
+.indicator-visibility::indicator:checked,
+.indicator-visibility::indicator:checked:hover {
     image: url(theme:Dark/visible.svg);
 }
 
-* [themeID="revertIcon"] {
-    qproperty-icon: url(theme:Dark/revert.svg);
-}
-
 /* Mute CheckBox */
-MuteCheckBox::indicator:checked {
+.indicator-mute::indicator:checked {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:indeterminate {
+.indicator-mute::indicator:indeterminate {
     image: url(theme:Dark/unassigned.svg);
 }
 
-MuteCheckBox::indicator:unchecked {
+.indicator-mute::indicator:unchecked {
     image: url(theme:Dark/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:unchecked:hover {
+.indicator-mute::indicator:unchecked:hover {
     image: url(theme:Dark/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:unchecked:focus {
+.indicator-mute::indicator:unchecked:focus {
     image: url(theme:Dark/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:checked:hover {
+.indicator-mute::indicator:checked:hover {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:checked:focus {
+.indicator-mute::indicator:checked:focus {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:checked:disabled {
+.indicator-mute::indicator:checked:disabled {
     image: url(theme:Dark/mute.svg);
 }
 
-MuteCheckBox::indicator:unchecked:disabled {
+.indicator-mute::indicator:unchecked:disabled {
     image: url(theme:Dark/settings/audio.svg);
 }
 
 /* Sources List Group Collapse Checkbox */
-QCheckBox[sourceTreeSubItem=true]::indicator:checked,
-QCheckBox[sourceTreeSubItem=true]::indicator:checked:hover {
+.indicator-expand::indicator:checked,
+.indicator-expand::indicator:checked:hover {
     image: url(theme:Dark/expand.svg);
 }
 
-QCheckBox[sourceTreeSubItem=true]::indicator:unchecked,
-QCheckBox[sourceTreeSubItem=true]::indicator:unchecked:hover {
+.indicator-expand::indicator:unchecked,
+.indicator-expand::indicator:unchecked:hover {
     image: url(theme:Dark/collapse.svg);
 }
 
@@ -268,36 +300,6 @@ OBSBasic {
     qproperty-sceneIcon: url(theme:Dark/sources/scene.svg);
     qproperty-defaultIcon: url(theme:Dark/sources/default.svg);
     qproperty-audioProcessOutputIcon: url(theme:Dark/sources/windowaudio.svg);
-}
-
-/* Save icon */
-* [themeID="replayIconSmall"] {
-    qproperty-icon: url(theme:Dark/save.svg);
-}
-
-/* Media icons */
-* [themeID="playIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_play.svg);
-}
-
-* [themeID="pauseIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_pause.svg);
-}
-
-* [themeID="restartIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_restart.svg);
-}
-
-* [themeID="stopIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_stop.svg);
-}
-
-* [themeID="nextIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_next.svg);
-}
-
-* [themeID="previousIcon"] {
-    qproperty-icon: url(theme:Dark/media/media_previous.svg);
 }
 
 /* YouTube Integration */


### PR DESCRIPTION
- fixes https://github.com/catppuccin/obs/issues/15
- style: indent properly & some lints
- replaced all `themeID=` and style hints with new OBS classes properties `* [themeID="clearIconSmall"]` -> `.icon-clear`
  - see https://github.com/obsproject/obs-studio/commit/cb026964b00c366943a3c16dfb1511eafc24c035
- updated theme to match Yami OBS theme

visual changes:
- fixes https://github.com/catppuccin/obs/issues/15
- theme new `scale to window` bar
![image](https://github.com/user-attachments/assets/7df94a52-781d-47d6-baf3-99f736c69103)

