### PR TITLE
feat: Qtool bar revamp

### DIFF
--- a/themes/Catppuccin.obt
+++ b/themes/Catppuccin.obt
@@ -690,6 +690,10 @@ QToolBar {
     margin: var(--spacing_base) 0px;
 }
 
+QToolBar QToolBarSeparator {
+    background-color: var(--ctp_surface0);
+}
+
 QToolBarExtension {
     background: palette(button);
     min-width: 12px;

--- a/themes/Catppuccin.obt
+++ b/themes/Catppuccin.obt
@@ -1098,7 +1098,7 @@ QPushButton:disabled {
 
 QToolButton:disabled,
 .btn-tool:disabled {
-    background-color: var(--ctp_crust);
+    background-color: transparent;
     border-color: transparent;
 }
 


### PR DESCRIPTION
- makes QToolBar separators visible
![Qtoolbar](https://github.com/user-attachments/assets/c7807fae-33cf-4c4a-8c47-88a96c99831e)
- make disabled buttons have transparent background like in OBS yami theme
