### PR TITLE
fix: wrong control dock button text color contrast

### DIFF
--- a/themes/Catppuccin.obt
+++ b/themes/Catppuccin.obt
@@ -996,6 +996,7 @@ QDoubleSpinBox::down-arrow {
 #modeSwitch:!hover:!pressed:checked,
 #broadcastButton:!hover:!pressed:checked {
     background: var(--ctp_blue);
+    color: var(--ctp_crust);
 }
 
 /* Primary Control Button Hover Coloring */


### PR DESCRIPTION
fixes text color in active control dock (start streaming, start recording, studio mode)
- fixes the whitish text on colored background