### PR TITLE
feat: update to OBS 31.1.1 theme

### DIFF
--- a/themes/Catppuccin.obt
+++ b/themes/Catppuccin.obt
@@ -989,23 +989,23 @@ QDoubleSpinBox::down-arrow {
 }
 
 /* Primary Control Button Checked Coloring */
-#streamButton:!hover:!pressed:checked,
-#recordButton:!hover:!pressed:checked,
-#replayBufferButton:!hover:!pressed:checked,
-#virtualCamButton:!hover:!pressed:checked,
-#modeSwitch:!hover:!pressed:checked,
-#broadcastButton:!hover:!pressed:checked {
+#streamButton:!hover:!pressed.state-active,
+#recordButton:!hover:!pressed.state-active,
+#replayBufferButton:!hover:!pressed.state-active,
+#virtualCamButton:!hover:!pressed.state-active,
+#modeSwitch:!hover:!pressed.state-active,
+#broadcastButton:!hover:!pressed.state-active {
     background: var(--ctp_blue);
     color: var(--ctp_crust);
 }
 
 /* Primary Control Button Hover Coloring */
-#streamButton:hover:!pressed:checked,
-#recordButton:hover:!pressed:checked,
-#replayBufferButton:!pressed:checked,
-#virtualCamButton:!pressed:checked,
-#modeSwitch:hover:!pressed:checked,
-#broadcastButton:hover:!pressed:checked {
+#streamButton:hover:!pressed.state-active,
+#recordButton:hover:!pressed.state-active,
+#replayBufferButton:!pressed.state-active,
+#virtualCamButton:!pressed.state-active,
+#modeSwitch:hover:!pressed.state-active,
+#broadcastButton:hover:!pressed.state-active {
     background: var(--ctp_lavender);
     color: var(--ctp_crust);
 }


### PR DESCRIPTION
The change adapts some changes in the recent release.

Resolves: https://github.com/catppuccin/obs/issues/19

Before (button pressed):

<img width="588" height="256" alt="image" src="https://github.com/user-attachments/assets/bb9e491f-be62-4e05-9678-2e513d9ff62e" />

After (button pressed):

<img width="590" height="290" alt="screenshot-20250729-125053" src="https://github.com/user-attachments/assets/37dd8ec7-4c48-42cc-a969-9d9c473f3737" />

